### PR TITLE
Retry on 429 or 504 requests

### DIFF
--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -224,7 +224,7 @@ def authed_request(source, url, method, data=None, headers=None):
 
             response = session.request(method, url, data=data)
 
-            if response.status_code == 429:
+            if response.status_code in [429, 504]:
                 retryCount += 1
                 response = None
                 # exponential backoff + 5-10 second jitter


### PR DESCRIPTION
We have seen multiple times that bitbucket will temporarily return 504's and entire jobs are failing because of it.