### PR TITLE
update rate-limiting backoff

### DIFF
--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -210,7 +210,7 @@ def authed_request(source, url, method, data=None, headers=None):
     with metrics.http_request_timer(source) as timer:
         response = None
         retryCount = 0
-        maxRetries = 5
+        maxRetries = 8
         if headers is not None:
             session.headers.update(headers)
 
@@ -228,7 +228,7 @@ def authed_request(source, url, method, data=None, headers=None):
                 retryCount += 1
                 response = None
                 # exponential backoff + 5-10 second jitter
-                time.sleep(30 * (2**retryCount) + randint(5,10))
+                time.sleep(4 * (2**retryCount) + randint(2, 5))
                 continue
 
             if response.status_code != 200:

--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -207,34 +207,41 @@ def get_repo_metadata(repo_path):
     return repo_cache[repo_path]
 
 def authed_request(source, url, method, data=None, headers=None):
-    with metrics.http_request_timer(source) as timer:
-        response = None
-        retryCount = 0
-        maxRetries = 8
-        if headers is not None:
-            session.headers.update(headers)
+    
+    response = None
+    retryCount = 0
+    maxRetries = 8
+    if headers is not None:
+        session.headers.update(headers)
 
-        while response is None and retryCount < maxRetries:
-            if retryCount > 0:
-                logger.info(
-                    "retryCount = {} elapsed = {:.2f}s, requesting {} {}".format(
-                        retryCount, timer.elapsed(), method, url
-                    )
+    while response is None and retryCount < maxRetries:
+        if retryCount > 0:
+            logger.info(
+                "retryCount = {} elapsed = {:.2f}s, requesting {} {}".format(
+                    retryCount, timer.elapsed(), method, url
                 )
+            )
 
+        with metrics.http_request_timer(source) as timer:
+            timer.tags['url'] = url
+            timer.tags['method'] = method
             response = session.request(method, url, data=data)
-
-            if response.status_code in [429, 504]:
-                retryCount += 1
-                response = None
-                # exponential backoff + 5-10 second jitter
-                time.sleep(4 * (2**retryCount) + randint(2, 5))
-                continue
-
-            if response.status_code != 200:
-                raise_for_error(response, source, url)
-
             timer.tags[metrics.Tag.http_status_code] = response.status_code
+
+        if response.status_code in [429, 504]:
+            retryCount += 1
+            # exponential backoff + 2-5 second jitter
+            with singer.metrics.Timer('request_backoff', { 'retryCount': retryCount }) as backoff_timer:
+                backoff_timer.tags['backoff_type'] = 'exponential'
+                response = None
+                sleep_time = 5 * (2**retryCount) + randint(2, 5)
+                backoff_timer.tags['sleep_time'] = sleep_time
+                time.sleep(sleep_time)
+
+            continue
+
+        if response.status_code != 200:
+            raise_for_error(response, source, url)
 
     # This should only happen if retries where exceeded 
     if response is None:


### PR DESCRIPTION
This is the actual functional change. It changes the wait times for the exponential backoff.  This will prevent us from waiting 60+ seconds when the rate limit is a rolling limit.

Previous method
```
python -c "
from random import randint
maxRetries = 5
total = 0
for i in range(1, maxRetries):
    wait_time =  30 * (2**i) + randint(5,10)
    print(wait_time)
    total += wait_time
print(f'Total {total}')
"
```
Output
```
70
126
249
486
Total 931
```

New exponential backoff
```
python -c "
from random import randint
maxRetries = 8
total = 0
for i in range(1, maxRetries):
    wait_time =  5 * (2**i) + randint(2,5)
    print(wait_time)
    total += wait_time
print(f'Total {total}')
"
```
Output
```
12
22
44
84
163
325
643
Total 1293
```
