### PR TITLE
check for prop existence before using

### DIFF
--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -628,7 +628,8 @@ def get_pull_request_heads(repo_path):
     ):
         for pr in prs:
             prNumber = pr['id']
-            heads['refs/pull/{}/head'.format(prNumber)] = pr['source']['commit']['hash']
+            if pr.get('source') and pr['source'].get('commit'):
+                heads['refs/pull/{}/head'.format(prNumber)] = pr['source']['commit']['hash']
             if pr.get('merge_commit'):
                 heads['refs/pull/{}/merge'.format(prNumber)] = pr['merge_commit']['hash']
     return heads


### PR DESCRIPTION
We received the following non-transient error:
```
CRITICAL 'NoneType' object is not subscriptable
Traceback (most recent call last):
  File "/opt/tap-bitbucket/bin/tap-bitbucket", line 8, in <module>@tap_bitbucket 
    sys.exit(main())
  File "/opt/tap-bitbucket/lib/python3.9/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/tap-bitbucket/lib/python3.9/site-packages/tap_bitbucket/__init__.py", line 924, in main
    do_sync(config, args.state, catalog)
  File "/opt/tap-bitbucket/lib/python3.9/site-packages/tap_bitbucket/__init__.py", line 855, in do_sync
    heads = get_pull_request_heads(repo)
  File "/opt/tap-bitbucket/lib/python3.9/site-packages/tap_bitbucket/__init__.py", line 631, in get_pull_request_heads
    heads['refs/pull/{}/head'.format(prNumber)] = pr['source']['commit']['hash']
TypeError: 'NoneType' object is not subscriptable
```

This change checks for the existence of pr['source'] and pr['source']['commit'] before accessing the hash prop.

Validated by running this failing job locally to verify that it gets past the point at which it failed in prod.