### PR TITLE
clone early for commit files meta

### DIFF
--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -962,10 +962,10 @@ def main():
             logger=logger,
             commitsOnly='commit_files_meta' in selected_stream_ids)
 
-        # Clone repositories early if this is a files catalog
+        # Clone repositories early if this is a files catalog or commit-files-meta catalog
         # the other tap doesn't need this
-        if args.properties_path and "files-catalog" in args.properties_path:
-            logger.info("Cloning repositories for files catalog")
+        if args.properties_path and ("files-catalog" in args.properties_path or "commit-files-meta-catalog" in args.properties_path):
+            logger.info("Cloning repositories early to avoid token expiration")
             repositories = list(filter(None, config['repository'].split(' ')))
             for repo in repositories:
                 logger.info("Cloning repository: %s", repo)

--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -964,7 +964,8 @@ def main():
 
         # Clone repositories early if this is a files catalog or commit-files-meta catalog
         # the other tap doesn't need this
-        if args.properties_path and ("files-catalog" in args.properties_path or "commit-files-meta-catalog" in args.properties_path):
+        files_catalogs = ("files-catalog", "files-meta-catalog")
+        if args.properties_path and any(catalog in args.properties_path for catalog in files_catalogs):
             logger.info("Cloning repositories early to avoid token expiration")
             repositories = list(filter(None, config['repository'].split(' ')))
             for repo in repositories:


### PR DESCRIPTION
For large repositories, the token was expiring before cloning the repository when trying to process commit files meta.

Previously we'd solved this problem for commit files. This change applies the same solution for commit files meta.

This was validated by running dev-ingest for both commit files and commit files meta configs for an repo that failed in prod and observing that the repository was cloned early in both instances.