### PR TITLE
update minware-singer-utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import os
 
-UTILS_VERSION = "e99e96ad3012b67e542590464a307ab05bff7f7a"
+UTILS_VERSION = "756eaa55ae05c44a58124a26e839698c2f5b78cc"
 
 setup(name='tap-bitbucket',
       version='1.0.0',


### PR DESCRIPTION
Update minware-singer-utils to get the clone retry update. Tested with https://github.com/minwareco/minware-singer-utils/pull/16