### PR TITLE
MW-9369: Use environment variable for minware-singer-utils version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import os
 
-UTILS_VERSION = "756eaa55ae05c44a58124a26e839698c2f5b78cc"
+UTILS_VERSION = os.environ.get("UTILS_VERSION")
 
 setup(name='tap-bitbucket',
       version='1.0.0',


### PR DESCRIPTION
Use UTILS_VERSION environment variable to control minware-singer-utils version dynamically