### PR TITLE
Handle GitLocalRepoNotFoundException to skip unavailable repos

### DIFF
--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -884,58 +884,58 @@ def do_sync(config, state, catalog, gitLocal):
 
         try:
             for stream in catalog['streams']:
-            stream_id = stream['tap_stream_id']
-            stream_schema = stream['schema']
-            mdata = stream['metadata']
+                stream_id = stream['tap_stream_id']
+                stream_schema = stream['schema']
+                mdata = stream['metadata']
 
-            # if it is a "sub_stream", it will be sync'd by its parent
-            if not SYNC_FUNCTIONS.get(stream_id):
-                continue
+                # if it is a "sub_stream", it will be sync'd by its parent
+                if not SYNC_FUNCTIONS.get(stream_id):
+                    continue
 
-            # if stream is selected, write schema and sync
-            if stream_id in selected_stream_ids:
-                singer.write_schema(stream_id, stream_schema, stream['key_properties'])
+                # if stream is selected, write schema and sync
+                if stream_id in selected_stream_ids:
+                    singer.write_schema(stream_id, stream_schema, stream['key_properties'])
 
-                # get sync function and any sub streams
-                sync_func = SYNC_FUNCTIONS[stream_id]
-                sub_stream_ids = SUB_STREAMS.get(stream_id, None)
+                    # get sync function and any sub streams
+                    sync_func = SYNC_FUNCTIONS[stream_id]
+                    sub_stream_ids = SUB_STREAMS.get(stream_id, None)
 
-                # sync stream
-                if not sub_stream_ids:
-                    if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
-                        commits_only = stream_id == 'commit_files_meta'
+                    # sync stream
+                    if not sub_stream_ids:
+                        if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
+                            commits_only = stream_id == 'commit_files_meta'
+                            stream_schemas = {stream_id: stream_schema}
+                            # Add refs schema if refs stream is selected
+                            if 'refs' in selected_stream_ids:
+                                refs_stream = get_stream_from_catalog('refs', catalog)
+                                stream_schemas['refs'] = refs_stream['schema']
+                            heads = get_pull_request_heads(repo)
+                            state = sync_func(stream_schemas, org, repo, state, mdata, start_date, gitLocal, heads, commits_only, selected_stream_ids)
+                        else:
+                            state = sync_func(stream_schema, repo, state, mdata, start_date)
+
+                    # handle streams with sub streams
+                    else:
                         stream_schemas = {stream_id: stream_schema}
-                        # Add refs schema if refs stream is selected
-                        if 'refs' in selected_stream_ids:
-                            refs_stream = get_stream_from_catalog('refs', catalog)
-                            stream_schemas['refs'] = refs_stream['schema']
-                        heads = get_pull_request_heads(repo)
-                        state = sync_func(stream_schemas, org, repo, state, mdata, start_date, gitLocal, heads, commits_only, selected_stream_ids)
-                    else:
-                        state = sync_func(stream_schema, repo, state, mdata, start_date)
 
-                # handle streams with sub streams
-                else:
-                    stream_schemas = {stream_id: stream_schema}
+                        # get and write selected sub stream schemas
+                        for sub_stream_id in sub_stream_ids:
+                            if sub_stream_id in selected_stream_ids:
+                                sub_stream = get_stream_from_catalog(sub_stream_id, catalog)
+                                stream_schemas[sub_stream_id] = sub_stream['schema']
+                                singer.write_schema(sub_stream_id, sub_stream['schema'],
+                                                    sub_stream['key_properties'])
 
-                    # get and write selected sub stream schemas
-                    for sub_stream_id in sub_stream_ids:
-                        if sub_stream_id in selected_stream_ids:
-                            sub_stream = get_stream_from_catalog(sub_stream_id, catalog)
-                            stream_schemas[sub_stream_id] = sub_stream['schema']
-                            singer.write_schema(sub_stream_id, sub_stream['schema'],
-                                                sub_stream['key_properties'])
-
-                    # sync stream and its sub streams
-                    if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
-                        heads = get_pull_request_heads(repo)
-                        # We don't need to also get open branch heads here becuase those are
-                        # included in the git clone --mirror, though PR heads for merged PRs are
-                        # not included.
-                        commits_only = stream_id == 'commit_files_meta'
-                        state = sync_func(stream_schemas, org, repo, state, mdata, start_date, gitLocal, heads, commits_only, selected_stream_ids)
-                    else:
-                        state = sync_func(stream_schemas, org, repo, state, mdata, start_date)
+                        # sync stream and its sub streams
+                        if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
+                            heads = get_pull_request_heads(repo)
+                            # We don't need to also get open branch heads here becuase those are
+                            # included in the git clone --mirror, though PR heads for merged PRs are
+                            # not included.
+                            commits_only = stream_id == 'commit_files_meta'
+                            state = sync_func(stream_schemas, org, repo, state, mdata, start_date, gitLocal, heads, commits_only, selected_stream_ids)
+                        else:
+                            state = sync_func(stream_schemas, org, repo, state, mdata, start_date)
 
         except GitLocalRepoNotFoundException as e:
             logger.warning(f'Repository {repo} not found, skipping: {e}')

--- a/tap_bitbucket/__init__.py
+++ b/tap_bitbucket/__init__.py
@@ -19,7 +19,7 @@ import jwt
 from random import randint
 import sys
 
-from minware_singer_utils import GitLocal, SecureLogger
+from minware_singer_utils import GitLocal, GitLocalRepoNotFoundException, SecureLogger
 
 from singer import metadata
 
@@ -882,7 +882,8 @@ def do_sync(config, state, catalog, gitLocal):
 
         org = repo.split('/')[0]
 
-        for stream in catalog['streams']:
+        try:
+            for stream in catalog['streams']:
             stream_id = stream['tap_stream_id']
             stream_schema = stream['schema']
             mdata = stream['metadata']
@@ -935,6 +936,10 @@ def do_sync(config, state, catalog, gitLocal):
                         state = sync_func(stream_schemas, org, repo, state, mdata, start_date, gitLocal, heads, commits_only, selected_stream_ids)
                     else:
                         state = sync_func(stream_schemas, org, repo, state, mdata, start_date)
+
+        except GitLocalRepoNotFoundException as e:
+            logger.warning(f'Repository {repo} not found, skipping: {e}')
+            continue
 
     # The state can get big, don't write it until the end
     singer.write_state(state)
@@ -1024,7 +1029,11 @@ def main():
             repositories = list(filter(None, config['repository'].split(' ')))
             for repo in repositories:
                 logger.info("Cloning repository: %s", repo)
-                git_local._initRepo(repo, git_local._getRepoWorkingDir(repo))
+                try:
+                    git_local._initRepo(repo, git_local._getRepoWorkingDir(repo))
+                except GitLocalRepoNotFoundException as e:
+                    logger.warning(f'Repository {repo} not found during early clone, skipping: {e}')
+                    continue
 
         do_sync(config, args.state, catalog, git_local)
 


### PR DESCRIPTION
## Summary
- Catches `GitLocalRepoNotFoundException` in both the early clone path (`main()`) and the sync loop (`do_sync()`) to skip unavailable repos instead of failing the entire ingest job
- Logs a warning and continues to the next repository

## Test plan
- [ ] Verify unavailable repos are skipped gracefully during ingest
- [ ] Verify other `GitLocalException` errors still propagate

Depends on: minwareco/minware-singer-utils#22
Jira: [MW-10497](https://minware.atlassian.net/browse/MW-10497)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MW-10497]: https://minware.atlassian.net/browse/MW-10497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ